### PR TITLE
Improve tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,22 @@
 language: php
 
-php:
-  - 5.4
-  - 5.5
-  - 5.6
-  - 7.0
-  - 7.1
-  - 7.2
-  - nightly
-
 matrix:
   include:
     - php: 5.3
       dist: precise
+    - php: 5.4
+      dist: trusty
+    - php: 5.5
+      dist: trusty
+    - php: 5.6
+    - php: 7.0
+    - php: 7.1
+    - php: 7.2
+    - php: 7.3
+    - php: 7.4
+    - php: nightly
+  allow_failures:
+    - php: nightly
 
 before_script:
   - composer install

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "phpunit/phpunit": "^4.8 || ^6.5"
     },
     "autoload": {
-        "psr-0": { "Transliterator\\": "src/" }
+        "psr-4": { "Transliterator\\": "src/Transliterator/" }
     },
     "autoload-dev": {
         "psr-4": {


### PR DESCRIPTION
# Changed log
- Since the Travis CI about default dist settings are changed, defining the matrix PHP versions and different dist for tests.
- The `PSR-0` autoloading is deprecated and using the `PSR-4` autoloading is instead.